### PR TITLE
Drop math from Requirements

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -51,8 +51,6 @@ Requirements
 
 - Python 3.9
 - PyTorch 2.0.0
-- math 
-
 
 Installation
 ------------


### PR DESCRIPTION
[math](https://docs.python.org/3.9/library/math.html) is a builtin Python library. There is no need to list it as requirements.